### PR TITLE
multiplexing and subdocuments support for illumi yjs

### DIFF
--- a/YDotNet.Server.MongoDB/YDotNet.Server.MongoDB.csproj
+++ b/YDotNet.Server.MongoDB/YDotNet.Server.MongoDB.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Version>0.5.0</Version>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/YDotNet.Server.WebSockets/ClientState.cs
+++ b/YDotNet.Server.WebSockets/ClientState.cs
@@ -94,12 +94,14 @@ public sealed class ClientState : IDisposable
         Decoder.Dispose();
     }
 
-    public void EnchanceWithClientId(ulong clientId)
+    public void EnchanceWithClientId(string docId, ulong clientId)
     {
-        DocumentContext = DocumentContext with { ClientId = clientId };
-        
-        var subDocsKeys = _subDocuments.Values.ToArray();
-        foreach (var subDoc in subDocsKeys)
+        if(docId==DocumentName)
+        {
+            DocumentContext = DocumentContext with { ClientId = clientId };
+            return;
+        }
+        if (_subDocuments.TryGetValue(docId, out var subDoc))
         {
             _subDocuments.TryUpdate(subDoc.Context.DocumentName,
                 subDoc with { Context = subDoc.Context with { ClientId = clientId } },

--- a/YDotNet.Server.WebSockets/ClientState.cs
+++ b/YDotNet.Server.WebSockets/ClientState.cs
@@ -1,6 +1,11 @@
+using System.Collections.Concurrent;
 using System.Net.WebSockets;
+using System.Security;
+using Microsoft.Extensions.Logging;
 
 namespace YDotNet.Server.WebSockets;
+
+public record SubDocumentContext(DocumentContext Context, Queue<byte[]> PendingUpdates, bool IsSynced);
 
 public sealed class ClientState : IDisposable
 {
@@ -14,18 +19,19 @@ public sealed class ClientState : IDisposable
 
     required public DocumentContext DocumentContext { get; set; }
 
-    required public string DocumentName { get; init; }
+    public string DocumentName => this.DocumentContext.DocumentName;
 
+    public IReadOnlyDictionary<string, SubDocumentContext> SubDocuments => _subDocuments;
+    private readonly ConcurrentDictionary<string,SubDocumentContext>  _subDocuments = new(StringComparer.Ordinal);
     public bool IsSynced { get; set; }
-
-    public Queue<byte[]> PendingUpdates { get; } = new Queue<byte[]>();
-
-    public async Task WriteLockedAsync<T>(T state, Func<WebSocketEncoder, T, ClientState, CancellationToken, Task> action, CancellationToken ct)
+    public Queue<byte[]> PendingUpdates { get; } = new();
+    
+    public async Task WriteLockedAsync<T>(T message, Func<WebSocketEncoder, T, ClientState, CancellationToken, Task> action, CancellationToken ct)
     {
         await slimLock.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-            await action(Encoder, state, this, ct).ConfigureAwait(false);
+            await action(Encoder, message, this, ct).ConfigureAwait(false);
         }
         finally
         {
@@ -33,11 +39,71 @@ public sealed class ClientState : IDisposable
         }
     }
 
+    public void AddPendingUpdate(string docId, byte[] update)
+    {
+        if( docId == DocumentName )
+        {
+            PendingUpdates.Enqueue(update);
+        }
+        else
+        {
+            if (!_subDocuments.TryGetValue(docId, out var subDoc))
+            {
+                throw new InvalidOperationException($"Subdocument not found: {docId}");
+            }
+
+            subDoc.PendingUpdates.Enqueue(update);
+        }
+    }
+
+    public DocumentContext GetOrInitDocument(string docId)
+    {
+       // ValidateDocument(docId);
+        if (docId == DocumentName)
+            return DocumentContext;
+        
+        if (_subDocuments.TryGetValue(docId, out var subDoc))
+            return subDoc.Context;
+
+        var newSubDoc =   _subDocuments.AddOrUpdate(docId,id=>
+                new SubDocumentContext(DocumentContext with { DocumentName = docId }, new Queue<byte[]>(), false),
+                (id,ctx) => ctx);
+        return newSubDoc.Context;
+    }
+    
+    
+
+    private bool IsExisting(string docId)
+    {
+        if (DocumentName == docId) return true;
+        if (SubDocuments.ContainsKey(docId)) return true;
+        return false;
+    }
+
+    public void EnsureExists(string docId)
+    {
+       if (!IsExisting(docId))
+           throw new InvalidOperationException($"Invalid document id: {docId}, it is neither state root doc neither a subdocument of {DocumentName}");
+    }
+    
     public void Dispose()
     {
         WebSocket.Dispose();
 
         Encoder.Dispose();
         Decoder.Dispose();
+    }
+
+    public void EnchanceWithClientId(ulong clientId)
+    {
+        DocumentContext = DocumentContext with { ClientId = clientId };
+        
+        var subDocsKeys = _subDocuments.Values.ToArray();
+        foreach (var subDoc in subDocsKeys)
+        {
+            _subDocuments.TryUpdate(subDoc.Context.DocumentName,
+                subDoc with { Context = subDoc.Context with { ClientId = clientId } },
+                subDoc);
+        }
     }
 }

--- a/YDotNet.Server.WebSockets/YDotNet.Server.WebSockets.csproj
+++ b/YDotNet.Server.WebSockets/YDotNet.Server.WebSockets.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Version>0.5.0</Version>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/YDotNet.Server.WebSockets/YDotNetSocketMiddleware.cs
+++ b/YDotNet.Server.WebSockets/YDotNetSocketMiddleware.cs
@@ -38,7 +38,7 @@ public sealed class YDotNetSocketMiddleware : IDocumentCallback
             {
                 await state.WriteLockedAsync(@event, async (encoder, e, _, ct) =>
                 {
-                    var message = new AwarenessMessage(new AwarenessInformation(e.Context.ClientId, e.ClientClock, (string?)e.ClientState));
+                    var message = new AwarenessMessage(@event.Context.DocumentName,new AwarenessInformation(e.Context.ClientId, e.ClientClock, (string?)e.ClientState));
 
                     await encoder.WriteAsync(message, ct).ConfigureAwait(false);
                 }, default).ConfigureAwait(false);
@@ -279,6 +279,7 @@ public sealed class YDotNetSocketMiddleware : IDocumentCallback
 
         var message =
             new AwarenessMessage(
+                state.DocumentContext.DocumentName,
                 users.Select(client => new AwarenessInformation(
                     client.Key,
                     client.Value.ClientClock,

--- a/YDotNet/Protocol/Messages.cs
+++ b/YDotNet/Protocol/Messages.cs
@@ -70,7 +70,7 @@ public record UnknownSyncMessage(ulong Identifier) : SyncMessage;
 /// <remarks>
 /// See: https://github.com/yjs/y-protocols/blob/master/sync.js.
 /// </remarks>
-public record SyncStep1Message(byte[] StateVector) : SyncMessage
+public record SyncStep1Message(byte[] StateVector, string DocId) : SyncMessage
 {
     /// <summary>
     /// Identifier for the this message.
@@ -84,7 +84,7 @@ public record SyncStep1Message(byte[] StateVector) : SyncMessage
 /// <remarks>
 /// See: https://github.com/yjs/y-protocols/blob/master/sync.js.
 /// </remarks>
-public record SyncStep2Message(byte[] Update) : SyncMessage
+public record SyncStep2Message(byte[] Update, string DocId) : SyncMessage
 {
     /// <summary>
     /// Identifier for the this message.
@@ -98,7 +98,7 @@ public record SyncStep2Message(byte[] Update) : SyncMessage
 /// <remarks>
 /// See: https://github.com/yjs/y-protocols/blob/master/sync.js#L40.
 /// </remarks>
-public record SyncUpdateMessage(byte[] Update) : SyncMessage
+public record SyncUpdateMessage(byte[] Update, string DocId) : SyncMessage
 {
     /// <summary>
     /// Identifier for the this message.

--- a/YDotNet/Protocol/Messages.cs
+++ b/YDotNet/Protocol/Messages.cs
@@ -112,7 +112,7 @@ public record SyncUpdateMessage(byte[] Update, string DocId) : SyncMessage
 /// <remarks>
 /// See: https://github.com/yjs/y-protocols/blob/master/awareness.js.
 /// </remarks>
-public record AwarenessMessage(params AwarenessInformation[] Clients) : BaseMessage
+public record AwarenessMessage(string DocId, params AwarenessInformation[] Clients) : BaseMessage
 {
     /// <summary>
     /// Identifier for the awareness message.

--- a/YDotNet/Protocol/ProtocolReadExtensions.cs
+++ b/YDotNet/Protocol/ProtocolReadExtensions.cs
@@ -76,6 +76,7 @@ public static class ProtocolReadExtensions
     /// <exception cref="InvalidOperationException">Protocol error occurred.</exception>
     private static async Task<AwarenessMessage> ReadAwarenessMessageAsync(this Decoder decoder, CancellationToken ct)
     {
+        var docId = await decoder.ReadVarStringAsync(ct).ConfigureAwait(false);
         // This is the length of the awareness message (for whatever reason).
         await decoder.ReadVarUintAsync(ct).ConfigureAwait(false);
 
@@ -92,6 +93,6 @@ public static class ProtocolReadExtensions
             clientList.Add(new AwarenessInformation(clientId, clientClock, clientState));
         }
 
-        return new AwarenessMessage(clientList.ToArray());
+        return new AwarenessMessage(docId, clientList.ToArray());
     }
 }

--- a/YDotNet/Protocol/ProtocolReadExtensions.cs
+++ b/YDotNet/Protocol/ProtocolReadExtensions.cs
@@ -41,24 +41,24 @@ public static class ProtocolReadExtensions
     /// <exception cref="InvalidOperationException">Protocol error occurred.</exception>
     public static async ValueTask<SyncMessage> ReadSyncMessageAsync(this Decoder decoder, CancellationToken ct)
     {
+        var docId = await decoder.ReadVarStringAsync(ct).ConfigureAwait(false);
         var syncType = await decoder.ReadVarUintAsync(ct).ConfigureAwait(false);
-
         switch (syncType)
         {
             case SyncStep1Message.Identifier:
                 var stateVector = await decoder.ReadVarUint8ArrayAsync(ct).ConfigureAwait(false);
 
-                return new SyncStep1Message(stateVector);
+                return new SyncStep1Message(stateVector, docId);
 
             case SyncStep2Message.Identifier:
                 var syncUpdate = await decoder.ReadVarUint8ArrayAsync(ct).ConfigureAwait(false);
 
-                return new SyncStep2Message(syncUpdate);
+                return new SyncStep2Message(syncUpdate, docId);
 
             case SyncUpdateMessage.Identifier:
                 var update = await decoder.ReadVarUint8ArrayAsync(ct).ConfigureAwait(false);
 
-                return new SyncUpdateMessage(update);
+                return new SyncUpdateMessage(update, docId);
 
             default:
                 return new UnknownSyncMessage(syncType);

--- a/YDotNet/Protocol/ProtocolWriteExtensions.cs
+++ b/YDotNet/Protocol/ProtocolWriteExtensions.cs
@@ -120,6 +120,7 @@ public static class ProtocolWriteExtensions
         ArgumentNullException.ThrowIfNull(message);
 
         await encoder.WriteVarUintAsync(AwarenessMessage.Identifier, ct).ConfigureAwait(false);
+        await encoder.WriteVarStringAsync(message.DocId, ct).ConfigureAwait(false);
 
         var buffer = new BufferEncoder();
 

--- a/YDotNet/Protocol/ProtocolWriteExtensions.cs
+++ b/YDotNet/Protocol/ProtocolWriteExtensions.cs
@@ -20,6 +20,7 @@ public static class ProtocolWriteExtensions
         ArgumentNullException.ThrowIfNull(message);
 
         await encoder.WriteVarUintAsync(SyncMessage.BaseIdentifier, ct).ConfigureAwait(false);
+        await encoder.WriteVarStringAsync(message.DocId, ct).ConfigureAwait(false);
         await encoder.WriteVarUintAsync(SyncStep1Message.Identifier, ct).ConfigureAwait(false);
         await encoder.WriteVarUint8Array(message.StateVector, ct).ConfigureAwait(false);
         await encoder.FlushAsync(ct).ConfigureAwait(false);
@@ -40,6 +41,7 @@ public static class ProtocolWriteExtensions
         ArgumentNullException.ThrowIfNull(message);
 
         await encoder.WriteVarUintAsync(SyncMessage.BaseIdentifier, ct).ConfigureAwait(false);
+        await encoder.WriteVarStringAsync(message.DocId, ct).ConfigureAwait(false);
         await encoder.WriteVarUintAsync(SyncStep2Message.Identifier, ct).ConfigureAwait(false);
         await encoder.WriteVarUint8Array(message.Update, ct).ConfigureAwait(false);
         await encoder.FlushAsync(ct).ConfigureAwait(false);
@@ -60,6 +62,7 @@ public static class ProtocolWriteExtensions
         ArgumentNullException.ThrowIfNull(message);
 
         await encoder.WriteVarUintAsync(SyncMessage.BaseIdentifier, ct).ConfigureAwait(false);
+        await encoder.WriteVarStringAsync(message.DocId, ct).ConfigureAwait(false);
         await encoder.WriteVarUintAsync(SyncUpdateMessage.Identifier, ct).ConfigureAwait(false);
         await encoder.WriteVarUint8Array(message.Update, ct).ConfigureAwait(false);
         await encoder.FlushAsync(ct).ConfigureAwait(false);


### PR DESCRIPTION
Changed protocol to process target document messages
Introduced subdocuments support

Original message structure from y-websocket:
 [messageCode][messageSubcode][messageBody]
illumi message structure
 [messageCode][DocumentId][messageSubcode][messageBody]

leftovers: 
+ introduce illumi message code  [documentName][illumiMessageType][messageSubcode][messageBody]
+ adjust message field encoding order 
+ pack as nuget